### PR TITLE
Concurrency improvements

### DIFF
--- a/examples/wait_groups.go
+++ b/examples/wait_groups.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+func doSomething(i int, wg *sync.WaitGroup) {
+
+	fmt.Println("Function in background", i)
+	wg.Done()
+}
+
+func main() {
+	nums := []int{2, 3, 4}
+	var wg sync.WaitGroup
+	for _, x := range nums {
+		wg.Add(1)
+		go doSomething(x, &wg)
+	}
+	wg.Wait()
+}

--- a/main/main.go
+++ b/main/main.go
@@ -17,13 +17,15 @@ func main() {
 		fmt.Println("error exiting")
 	}
 
+	// need to name variables/files betterer
 	var graph graph.Graph
 
 	graph.CreateRandomGraph(nodeNumber)
+
 	graph.BroadcastNodeInfo()
 
-	// CHeating
-	var input string
-	fmt.Scanln(&input)
+	// CHeating - requires channel to indicate when all messages have finished sending
+	// var input string
+	// fmt.Scanln(&input)
 	graph.ConsensusResult()
 }

--- a/util/graph.go
+++ b/util/graph.go
@@ -97,7 +97,7 @@ func (graph *Graph) BroadcastNodeInfo() {
 	// var graphWg sync.WaitGroup
 	for _, node := range graph.nodes {
 		// graphWg.Add(1)
-		wg.Add(1)
+
 		go node.messageEdges()
 	}
 	// graphWg.Wait()
@@ -111,13 +111,11 @@ func (graph *Graph) BroadcastNodeInfo() {
 // large diameter graphs
 
 func (n *Node) messageEdges() {
-	defer wg.Done()
 	wg.Add(1)
 	go n.announceLargest()
 
 	for message := range n.messages {
 		if message > n.largest {
-			fmt.Printf("NODE %d New Largest ID %d\n", n.id, message)
 			n.mu.Lock()
 			n.largest = message // CONSIDER USING MUTEX FOR ALTERING THIS TO ENSURE ATOMICITY
 			n.mu.Unlock()
@@ -125,19 +123,14 @@ func (n *Node) messageEdges() {
 			go n.announceLargest()
 		}
 	}
-
 }
 
 // might be closing to early if other nodes are transfer message
 func (n *Node) announceLargest() {
 	defer wg.Done()
-
 	for _, e := range n.nodeEdges {
-		n.mu.Lock()
 		e.messages <- n.largest
-		n.mu.Unlock()
 	}
-
 }
 
 func (graph *Graph) ConsensusResult() {

--- a/util/graph.go
+++ b/util/graph.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"fmt"
 	"math/rand"
+	"sync"
 )
 
 type Node struct {
@@ -10,6 +11,7 @@ type Node struct {
 	largest   uint64
 	nodeEdges []*Node
 	messages  chan uint64
+	mu        sync.Mutex
 }
 
 type Leader struct {
@@ -20,6 +22,7 @@ type Leader struct {
 type Graph struct {
 	// a basic graph type that contains a list of references to associated nodes.
 	nodes []*Node
+	done  chan bool
 }
 
 func (graph *Graph) CreateRandomGraph(nodeNumber int) {
@@ -87,33 +90,54 @@ func (n *Node) getEdgeIds() []uint64 {
 	return edgeIds
 }
 
+var wg sync.WaitGroup
+
 func (graph *Graph) BroadcastNodeInfo() {
+
+	// var graphWg sync.WaitGroup
 	for _, node := range graph.nodes {
+		// graphWg.Add(1)
+		wg.Add(1)
 		go node.messageEdges()
 	}
+	// graphWg.Wait()
+	wg.Wait()
+
 }
 
+// receive message from queue - adjust largest if necessary
+// TODO: to prevent race condition lock value while it is being pulled from the queue
+// does this go routine exit prematurely and messages may be pushed on to the channel after it has exited -
+// large diameter graphs
+
 func (n *Node) messageEdges() {
-	// receive message from queue - adjust largest if necessary
-	// TODO: to prevent race condition lock value while it is being pulled from the queue
-	// does this go routine exit prematurely and messages may be pushed on to the channel after it has exited -
-	// large diameter graphs
+	defer wg.Done()
+	wg.Add(1)
 	go n.announceLargest()
+
 	for message := range n.messages {
 		if message > n.largest {
 			fmt.Printf("NODE %d New Largest ID %d\n", n.id, message)
+			n.mu.Lock()
 			n.largest = message // CONSIDER USING MUTEX FOR ALTERING THIS TO ENSURE ATOMICITY
-			// New Largest then announceLargest
+			n.mu.Unlock()
+			wg.Add(1)
 			go n.announceLargest()
 		}
 	}
+
 }
 
+// might be closing to early if other nodes are transfer message
 func (n *Node) announceLargest() {
+	defer wg.Done()
+
 	for _, e := range n.nodeEdges {
+		n.mu.Lock()
 		e.messages <- n.largest
-		// might be closing to early if other nodes are transfer message
+		n.mu.Unlock()
 	}
+
 }
 
 func (graph *Graph) ConsensusResult() {


### PR DESCRIPTION
- Added wait groups to broadcast methods to ensure that all broadcasts are finished before consensus of nodes is tallied. 
- Added mutex for field on node struct to prevent data race situation of two processes writing to the same variable